### PR TITLE
commit SHA:9c29d2e49da4636b85e43b92423278fca3639398

### DIFF
--- a/ric_description/config/ric_robot_control.yaml
+++ b/ric_description/config/ric_robot_control.yaml
@@ -1,0 +1,35 @@
+  # Publish all joint states -----------------------------------
+  joint_state_controller:
+    type: joint_state_controller/JointStateController
+    publish_rate: 50  
+  
+  # Position Controllers ---------------------------------------
+  base_rotation_controller:
+    type: effort_controllers/JointPositionController
+    joint: komodo_base_rotation_joint
+    pid: {p: 500.0, i: 0.00, d: 0}
+  shoulder_controller:
+    type: effort_controllers/JointPositionController
+    joint: komodo_shoulder_joint
+    pid: {p: 500.0, i: 0, d: 0.0}
+  elbow1_controller:
+    type: effort_controllers/JointPositionController
+    joint: komodo_elbow1_joint
+    pid: {p: 700.0, i: 0, d: 0.0}
+  elbow2_controller:
+    type: effort_controllers/JointPositionController
+    joint: komodo_elbow2_joint
+    pid: {p: 700.0, i: 0, d: 0.0}
+  wrist_controller:
+    type: effort_controllers/JointPositionController
+    joint: komodo_wrist_joint
+    pid: {p: 500.0, i: 0.0, d: 0.0}
+  left_finger_controller:
+    type: effort_controllers/JointPositionController
+    joint: komodo_left_finger_joint
+    pid: {p: 500.0, i: 0.0, d: 0.0}
+  right_finger_controller:
+    type: effort_controllers/JointPositionController
+    joint: komodo_right_finger_joint
+    pid: {p: 500.0, i: 0.0, d: 0.0}
+

--- a/ric_description/komodo/komodo.xacro
+++ b/ric_description/komodo/komodo.xacro
@@ -1,7 +1,26 @@
 <?xml version="1.0"?>
-<robot xmlns:xacro="http://www.ros.org/wiki/ric" name="ric_description">
+<robot
+  name="komodo_$(arg komodo_id)">
+<!-- Dummy inertia link & Joint -->
   <link
-    name="komodo_$(arg komodo_id)_base_link">
+    name="komodo_dummy_link">    
+</link>
+  <joint
+    name="komodo_dummy_joint"
+    type="fixed">
+    <origin
+      xyz="0.0 0.0 0.0"
+      rpy="0 0 0" />
+    <parent
+      link="komodo_dummy_link" />
+    <child
+      link="komodo_base_link" />
+    <axis
+      xyz="0 0 0" />
+  </joint>
+<!-- Dummy link & node -->
+  <link
+    name="komodo_base_link">
     <inertial>
       <origin
         xyz="-0.0205330571995271 4.54409684683429E-05 0.00735986203300292"
@@ -41,7 +60,7 @@
     </collision>
   </link>
   <link
-    name="komodo_$(arg komodo_id)_FR_Wheel_link">
+    name="komodo_FR_Wheel_link">
     <inertial>
       <origin
         xyz="-0.00160662478940524 -2.59227836232889E-06 1.49952129885679E-05"
@@ -83,20 +102,20 @@
     </collision>
   </link>
   <joint
-    name="komodo_$(arg komodo_id)_FR_Wheel_joint"
+    name="komodo_FR_Wheel_joint"
     type="continuous">
     <origin
       xyz="0.173999999999995 -0.2009 0"
       rpy="2.62229105359916E-15 6.9308460464278E-17 1.5707963267949" />
     <parent
-      link="komodo_$(arg komodo_id)_base_link" />
+      link="komodo_base_link" />
     <child
-      link="komodo_$(arg komodo_id)_FR_Wheel_link" />
+      link="komodo_FR_Wheel_link" />
     <axis
       xyz="1 0 0" />
   </joint>
   <link
-    name="komodo_$(arg komodo_id)_FL_Wheel_link">
+    name="komodo_FL_Wheel_link">
     <inertial>
       <origin
         xyz="-0.00160662480262744 -2.59228543311729E-06 1.49951351856364E-05"
@@ -138,20 +157,20 @@
     </collision>
   </link>
   <joint
-    name="komodo_$(arg komodo_id)_FL_Wheel_joint"
+    name="komodo_FL_Wheel_joint"
     type="continuous">
     <origin
       xyz="0.173999999999995 0.2009 0"
       rpy="-2.62229105359916E-15 6.93084604642783E-17 -1.5707963267949" />
     <parent
-      link="komodo_$(arg komodo_id)_base_link" />
+      link="komodo_base_link" />
     <child
-      link="komodo_$(arg komodo_id)_FL_Wheel_link" />
+      link="komodo_FL_Wheel_link" />
     <axis
       xyz="-1 0 0" />
   </joint>
   <link
-    name="komodo_$(arg komodo_id)_RR_Wheel_link">
+    name="komodo_RR_Wheel_link">
     <inertial>
       <origin
         xyz="-0.00160662476834383 -2.59238516814309E-06 1.49950507030127E-05"
@@ -193,20 +212,20 @@
     </collision>
   </link>
   <joint
-    name="komodo_$(arg komodo_id)_RR_Wheel_joint"
+    name="komodo_RR_Wheel_joint"
     type="continuous">
     <origin
       xyz="-0.156000000000005 -0.2009 0"
       rpy="2.62229105359916E-15 -1.59433090848306E-31 1.5707963267949" />
     <parent
-      link="komodo_$(arg komodo_id)_base_link" />
+      link="komodo_base_link" />
     <child
-      link="komodo_$(arg komodo_id)_RR_Wheel_link" />
+      link="komodo_RR_Wheel_link" />
     <axis
       xyz="1 0 0" />
   </joint>
   <link
-    name="komodo_$(arg komodo_id)_RL_Wheel_link">
+    name="komodo_RL_Wheel_link">
     <inertial>
       <origin
         xyz="-0.00160662477936549 -2.59222765522371E-06 1.49952106412736E-05"
@@ -248,20 +267,20 @@
     </collision>
   </link>
   <joint
-    name="komodo_$(arg komodo_id)_RL_Wheel_joint"
+    name="komodo_RL_Wheel_joint"
     type="continuous">
     <origin
       xyz="-0.156000000000005 0.2009 0"
       rpy="-2.62229105359916E-15 -5.57680208627196E-32 -1.5707963267949" />
     <parent
-      link="komodo_$(arg komodo_id)_base_link" />
+      link="komodo_base_link" />
     <child
-      link="komodo_$(arg komodo_id)_RL_Wheel_link" />
+      link="komodo_RL_Wheel_link" />
     <axis
       xyz="-1 0 0" />
   </joint>
   <link
-    name="komodo_$(arg komodo_id)_Left_URF_link">
+    name="komodo_Left_URF_link">
     <inertial>
       <origin
         xyz="-0.00942258060476561 1.68888278492922E-05 -0.000193183712129175"
@@ -301,20 +320,20 @@
     </collision>
   </link>
   <joint
-    name="komodo_$(arg komodo_id)_Left_URF_joint"
+    name="komodo_Left_URF_joint"
     type="fixed">
     <origin
       xyz="-0.0223133326154785 0.137250000000005 0.138508176066688"
       rpy="-2.73331335606168E-15 1.59433090848306E-31 1.5707963267949" />
     <parent
-      link="komodo_$(arg komodo_id)_base_link" />
+      link="komodo_base_link" />
     <child
-      link="komodo_$(arg komodo_id)_Left_URF_link" />
+      link="komodo_Left_URF_link" />
     <axis
       xyz="-1 0 0" />
   </joint>
   <link
-    name="komodo_$(arg komodo_id)_Rear_URF_link">
+    name="komodo_Rear_URF_link">
     <inertial>
       <origin
         xyz="-0.00942258060476558 1.68888278491873E-05 -0.000193183712129189"
@@ -354,20 +373,20 @@
     </collision>
   </link>
   <joint
-    name="komodo_$(arg komodo_id)_Rear_URF_joint"
+    name="komodo_Rear_URF_joint"
     type="fixed">
     <origin
       xyz="-0.267499972183238 0 0.107999999999999"
       rpy="-6.16297582203915E-33 2.73331335606168E-15 3.14159265358979" />
     <parent
-      link="komodo_$(arg komodo_id)_base_link" />
+      link="komodo_base_link" />
     <child
-      link="komodo_$(arg komodo_id)_Rear_URF_link" />
+      link="komodo_Rear_URF_link" />
     <axis
       xyz="-1 0 0" />
   </joint>
   <link
-    name="komodo_$(arg komodo_id)_Right_URF_link">
+    name="komodo_Right_URF_link">
     <inertial>
       <origin
         xyz="-0.00942258060476561 1.68888278493408E-05 -0.000193183712129202"
@@ -407,20 +426,20 @@
     </collision>
   </link>
   <joint
-    name="komodo_$(arg komodo_id)_Right_URF_joint"
+    name="komodo_Right_URF_joint"
     type="fixed">
     <origin
       xyz="-0.0223133326154785 -0.137249999999995 0.138508176066688"
       rpy="2.73331335606168E-15 -1.59433090848306E-31 -1.5707963267949" />
     <parent
-      link="komodo_$(arg komodo_id)_base_link" />
+      link="komodo_base_link" />
     <child
-      link="komodo_$(arg komodo_id)_Right_URF_link" />
+      link="komodo_Right_URF_link" />
     <axis
       xyz="-1 0 0" />
   </joint>
   <link
-    name="komodo_$(arg komodo_id)_Front_Camera_link">
+    name="komodo_Front_Camera_link">
     <inertial>
       <origin
         xyz="3.63553471578737E-06 0.000213443852909154 -0.00979905092954431"
@@ -460,20 +479,20 @@
     </collision>
   </link>
   <joint
-    name="komodo_$(arg komodo_id)_Front_Camera_joint"
+    name="komodo_Front_Camera_joint"
     type="fixed">
     <origin
       xyz="0.262250027816762 0.0875000000000051 0.100000000000001"
       rpy="-1.57079632679489 -6.93084604642783E-17 -1.5707963267949" />
     <parent
-      link="komodo_$(arg komodo_id)_base_link" />
+      link="komodo_base_link" />
     <child
-      link="komodo_$(arg komodo_id)_Front_Camera_link" />
+      link="komodo_Front_Camera_link" />
     <axis
       xyz="0 0 1" />
   </joint>
   <link
-    name="komodo_$(arg komodo_id)_Laser_link">
+    name="komodo_Laser_link">
     <inertial>
       <origin
         xyz="5.67786090348299E-05 -6.35639788811446E-05 -0.0320034700075499"
@@ -513,20 +532,20 @@
     </collision>
   </link>
   <joint
-    name="komodo_$(arg komodo_id)_Laser_joint"
+    name="komodo_Laser_joint"
     type="fixed">
     <origin
       xyz="0.234263427816762 0 0.145827195177237"
       rpy="-6.93084604642783E-17 -2.62229105359916E-15 5.55111512312578E-17" />
     <parent
-      link="komodo_$(arg komodo_id)_base_link" />
+      link="komodo_base_link" />
     <child
-      link="komodo_$(arg komodo_id)_Laser_link" />
+      link="komodo_Laser_link" />
     <axis
       xyz="0 0 -1" />
   </joint>
   <link
-    name="komodo_$(arg komodo_id)_Asus_Camera_link">
+    name="komodo_Asus_Camera_link">
     <inertial>
       <origin
         xyz="-0.0187798361475048 -0.000287133366772307 -0.000201032384153296"
@@ -566,20 +585,20 @@
     </collision>
   </link>
   <joint
-    name="komodo_$(arg komodo_id)_Asus_Camera_joint"
+    name="komodo_Asus_Camera_joint"
     type="fixed">
     <origin
       xyz="0.262250027816762 0 0.0635000000000008"
       rpy="-6.93084604642783E-17 -2.62229105359916E-15 5.55111512312578E-17" />
     <parent
-      link="komodo_$(arg komodo_id)_base_link" />
+      link="komodo_base_link" />
     <child
-      link="komodo_$(arg komodo_id)_Asus_Camera_link" />
+      link="komodo_Asus_Camera_link" />
     <axis
       xyz="-1 0 0" />
   </joint>
   <link
-    name="komodo_$(arg komodo_id)_Arm_base_link">
+    name="komodo_Arm_base_link">
     <inertial>
       <origin
         xyz="-0.0168723530982394 -5.23224904403848E-05 0.038112696778507"
@@ -619,20 +638,20 @@
     </collision>
   </link>
   <joint
-    name="komodo_$(arg komodo_id)_Arm_base_joint"
+    name="komodo_Arm_base_joint"
     type="fixed">
     <origin
       xyz="-0.112249972183238 0 0.167160698455407"
       rpy="3.54761842723405E-15 -3.56763412295181E-15 -3.35371649289343E-30" />
     <parent
-      link="komodo_$(arg komodo_id)_base_link" />
+      link="komodo_base_link" />
     <child
-      link="komodo_$(arg komodo_id)_Arm_base_link" />
+      link="komodo_Arm_base_link" />
     <axis
       xyz="0 0 1" />
   </joint>
   <link
-    name="komodo_$(arg komodo_id)_base_rotation_link">
+    name="komodo_base_rotation_link">
     <inertial>
       <origin
         xyz="-1.11022302462516E-16 -7.80223872637444E-17 0.0660708417371112"
@@ -672,15 +691,15 @@
     </collision>
   </link>
   <joint
-    name="komodo_$(arg komodo_id)_base_rotation_joint"
+    name="komodo_base_rotation_joint"
     type="revolute">
     <origin
       xyz="-0.096277996026178 0 0.0549000000000002"
       rpy="-5.46369598732866E-16 1.34659130519145E-15 -2.1922983760752E-31" />
     <parent
-      link="komodo_$(arg komodo_id)_Arm_base_link" />
+      link="komodo_Arm_base_link" />
     <child
-      link="komodo_$(arg komodo_id)_base_rotation_link" />
+      link="komodo_base_rotation_link" />
     <axis
       xyz="0 0 1" />
     <limit
@@ -690,7 +709,7 @@
       velocity="0" />
   </joint>
   <link
-    name="komodo_$(arg komodo_id)_shoulder_link">
+    name="komodo_shoulder_link">
     <inertial>
       <origin
         xyz="-4.66231481405233E-06 -9.82289126283389E-05 0.0772888499682157"
@@ -730,15 +749,15 @@
     </collision>
   </link>
   <joint
-    name="komodo_$(arg komodo_id)_shoulder_joint"
+    name="komodo_shoulder_joint"
     type="revolute">
     <origin
       xyz="0 0 0.0834999999999999"
       rpy="-4.20159904047482E-15 -5.97509793174248E-16 9.93431320775303E-15" />
     <parent
-      link="komodo_$(arg komodo_id)_base_rotation_link" />
+      link="komodo_base_rotation_link" />
     <child
-      link="komodo_$(arg komodo_id)_shoulder_link" />
+      link="komodo_shoulder_link" />
     <axis
       xyz="0 1 0" />
     <limit
@@ -748,7 +767,7 @@
       velocity="0" />
   </joint>
   <link
-    name="komodo_$(arg komodo_id)_elbow1_link">
+    name="komodo_elbow1_link">
     <inertial>
       <origin
         xyz="3.38561240652013E-05 2.66604610292575E-06 0.0239321015909688"
@@ -788,15 +807,15 @@
     </collision>
   </link>
   <joint
-    name="komodo_$(arg komodo_id)_elbow1_joint"
+    name="komodo_elbow1_joint"
     type="revolute">
     <origin
       xyz="0 -0.000251155668932789 0.266305434894181"
       rpy="1.44504380352115E-15 1.11628850952447E-06 -9.93431159466724E-15" />
     <parent
-      link="komodo_$(arg komodo_id)_shoulder_link" />
+      link="komodo_shoulder_link" />
     <child
-      link="komodo_$(arg komodo_id)_elbow1_link" />
+      link="komodo_elbow1_link" />
     <axis
       xyz="-0.999999999998754 0 0" />
     <limit
@@ -806,7 +825,7 @@
       velocity="0" />
   </joint>
   <link
-    name="komodo_$(arg komodo_id)_elbow2_link">
+    name="komodo_elbow2_link">
     <inertial>
       <origin
         xyz="-2.29085121194481E-05 -0.000512185919169572 0.0885118786028204"
@@ -846,15 +865,15 @@
     </collision>
   </link>
   <joint
-    name="komodo_$(arg komodo_id)_elbow2_joint"
+    name="komodo_elbow2_joint"
     type="revolute">
     <origin
       xyz="0 0 0.223999999999899"
       rpy="-4.51048856041191E-16 3.35869632765754E-16 0" />
     <parent
-      link="komodo_$(arg komodo_id)_elbow1_link" />
+      link="komodo_elbow1_link" />
     <child
-      link="komodo_$(arg komodo_id)_elbow2_link" />
+      link="komodo_elbow2_link" />
     <axis
       xyz="0 1 0" />
     <limit
@@ -864,7 +883,7 @@
       velocity="0" />
   </joint>
   <link
-    name="komodo_$(arg komodo_id)_wrist_link">
+    name="komodo_wrist_link">
     <inertial>
       <origin
         xyz="0 0 0"
@@ -904,15 +923,15 @@
     </collision>
   </link>
   <joint
-    name="komodo_$(arg komodo_id)_wrist_joint"
+    name="komodo_wrist_joint"
     type="revolute">
     <origin
       xyz="0.0137 0 0.244749999999997"
       rpy="0 0 0" />
     <parent
-      link="komodo_$(arg komodo_id)_elbow2_link" />
+      link="komodo_elbow2_link" />
     <child
-      link="komodo_$(arg komodo_id)_wrist_link" />
+      link="komodo_wrist_link" />
     <axis
       xyz="0 0 0.999999999998754" />
     <limit
@@ -922,7 +941,7 @@
       velocity="0" />
   </joint>
   <link
-    name="komodo_$(arg komodo_id)_left_finger_link">
+    name="komodo_left_finger_link">
     <inertial>
       <origin
         xyz="-6.10622663543836E-16 0.0205697573116852 0.0301832532936965"
@@ -962,15 +981,15 @@
     </collision>
   </link>
   <joint
-    name="komodo_$(arg komodo_id)_left_finger_joint"
+    name="komodo_left_finger_joint"
     type="revolute">
     <origin
       xyz="-0.000250000000000111 0.021 0.0422500000000001"
       rpy="2.85979682697881E-15 1.01870746742143E-16 3.19235832636806E-21" />
     <parent
-      link="komodo_$(arg komodo_id)_wrist_link" />
+      link="komodo_wrist_link" />
     <child
-      link="komodo_$(arg komodo_id)_left_finger_link" />
+      link="komodo_left_finger_link" />
     <axis
       xyz="1 0 0" />
     <limit
@@ -980,7 +999,7 @@
       velocity="0" />
   </joint>
   <link
-    name="komodo_$(arg komodo_id)_right_finger_link">
+    name="komodo_right_finger_link">
     <inertial>
       <origin
         xyz="2.77555756156289E-16 -0.0205697573116854 0.0301832532936965"
@@ -1020,15 +1039,15 @@
     </collision>
   </link>
   <joint
-    name="komodo_$(arg komodo_id)_right_finger_joint"
+    name="komodo_right_finger_joint"
     type="revolute">
     <origin
       xyz="-0.00024999999999889 -0.021 0.0422499999999999"
       rpy="0 3.19686557214722E-37 0" />
     <parent
-      link="komodo_$(arg komodo_id)_wrist_link" />
+      link="komodo_wrist_link" />
     <child
-      link="komodo_$(arg komodo_id)_right_finger_link" />
+      link="komodo_right_finger_link" />
     <axis
       xyz="1 0 0" />
     <limit
@@ -1038,7 +1057,7 @@
       velocity="0" />
   </joint>
   <link
-    name="komodo_$(arg komodo_id)_Arm_Camera_link">
+    name="komodo_Arm_Camera_link">
     <inertial>
       <origin
         xyz="3.63554297842268E-06 0.000213444909942184 -0.00979905208116372"
@@ -1078,20 +1097,20 @@
     </collision>
   </link>
   <joint
-    name="komodo_$(arg komodo_id)_Arm_camera_joint"
+    name="komodo_Arm_camera_joint"
     type="fixed">
     <origin
       xyz="-0.0552499999999999 0 0.0340250000000002"
       rpy="0 -1.57079632649567 0" />
     <parent
-      link="komodo_$(arg komodo_id)_wrist_link" />
+      link="komodo_wrist_link" />
     <child
-      link="komodo_$(arg komodo_id)_Arm_Camera_link" />
+      link="komodo_Arm_Camera_link" />
     <axis
       xyz="0 0 0.999999999998754" />
   </joint>
   <link
-    name="komodo_$(arg komodo_id)_sensors_unit_link">
+    name="komodo_sensors_unit_link">
     <inertial>
       <origin
         xyz="0.0414414719218708 -0.000373289194023478 0.0507806551833217"
@@ -1131,15 +1150,15 @@
     </collision>
   </link>
   <joint
-    name="komodo_$(arg komodo_id)_sensors_unit_joint"
+    name="komodo_sensors_unit_joint"
     type="fixed">
     <origin
       xyz="-0.00199997218323841 0 0.0835000000000001"
       rpy="-1.59433090848306E-31 -2.62229105359916E-15 5.55111512312578E-17" />
     <parent
-      link="komodo_$(arg komodo_id)_base_link" />
+      link="komodo_base_link" />
     <child
-      link="komodo_$(arg komodo_id)_sensors_unit_link" />
+      link="komodo_sensors_unit_link" />
     <axis
       xyz="1 0 0" />
   </joint>
@@ -1155,7 +1174,7 @@
 
   <transmission name="tran1">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="komodo_$(arg komodo_id)_FR_Wheel_joint">
+    <joint name="komodo_FR_Wheel_joint">
 <hardwareInterface>EffortJointInterface</hardwareInterface>
     </joint>
     <actuator name="motor1">
@@ -1166,7 +1185,7 @@
 
   <transmission name="tran2">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="komodo_$(arg komodo_id)_FL_Wheel_joint">
+    <joint name="komodo_FL_Wheel_joint">
 <hardwareInterface>EffortJointInterface</hardwareInterface>
     </joint>
     <actuator name="motor2">
@@ -1177,7 +1196,7 @@
 
   <transmission name="tran3">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="komodo_$(arg komodo_id)_RR_Wheel_joint">
+    <joint name="komodo_RR_Wheel_joint">
 <hardwareInterface>EffortJointInterface</hardwareInterface>
     </joint>
     <actuator name="motor3">
@@ -1188,7 +1207,7 @@
 
   <transmission name="tran4">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="komodo_$(arg komodo_id)_RL_Wheel_joint">
+    <joint name="komodo_RL_Wheel_joint">
 <hardwareInterface>EffortJointInterface</hardwareInterface>
     </joint>
     <actuator name="motor4">
@@ -1199,7 +1218,7 @@
 
   <transmission name="tran5">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="komodo_$(arg komodo_id)_base_rotation_joint">
+    <joint name="komodo_base_rotation_joint">
 <hardwareInterface>EffortJointInterface</hardwareInterface>
     </joint>
     <actuator name="motor5">
@@ -1210,7 +1229,7 @@
 
   <transmission name="tran6">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="komodo_$(arg komodo_id)_shoulder_joint">
+    <joint name="komodo_shoulder_joint">
 <hardwareInterface>EffortJointInterface</hardwareInterface>
 	</joint>
     <actuator name="motor6">
@@ -1221,7 +1240,7 @@
 
   <transmission name="tran7">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="komodo_$(arg komodo_id)_elbow1_joint">
+    <joint name="komodo_elbow1_joint">
 <hardwareInterface>EffortJointInterface</hardwareInterface>
 </joint>
     <actuator name="motor7">
@@ -1232,7 +1251,7 @@
 
   <transmission name="tran8">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="komodo_$(arg komodo_id)_elbow2_joint">
+    <joint name="komodo_elbow2_joint">
 <hardwareInterface>EffortJointInterface</hardwareInterface>
 </joint>
     <actuator name="motor8">
@@ -1243,7 +1262,7 @@
 
   <transmission name="tran9">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="komodo_$(arg komodo_id)_wrist_joint">
+    <joint name="komodo_wrist_joint">
 <hardwareInterface>EffortJointInterface</hardwareInterface>
 </joint>
     <actuator name="motor9">
@@ -1254,7 +1273,7 @@
 
   <transmission name="tran10">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="komodo_$(arg komodo_id)_left_finger_joint">
+    <joint name="komodo_left_finger_joint">
 <hardwareInterface>EffortJointInterface</hardwareInterface>
 </joint>
     <actuator name="motor10">
@@ -1265,7 +1284,7 @@
 
   <transmission name="tran11">
     <type>transmission_interface/SimpleTransmission</type>
-    <joint name="komodo_$(arg komodo_id)_right_finger_joint">
+    <joint name="komodo_right_finger_joint">
 <hardwareInterface>EffortJointInterface</hardwareInterface>
 </joint>
     <actuator name="motor11">
@@ -1276,85 +1295,85 @@
 
 <!-- New -->
 
-<gazebo reference="komodo_$(arg komodo_id)_base_rotation_link">
+<gazebo reference="komodo_base_rotation_link">
     <mu1>1</mu1>
     <mu2>1</mu2>
-    <selfCollide>true</selfCollide>
+    <!--selfCollide>true</selfCollide-->
    <material>Gazebo/Grey</material>
 </gazebo>
 
-<gazebo reference="komodo_$(arg komodo_id)_shoulder_link">
+<gazebo reference="komodo_shoulder_link">
     <mu1>1</mu1>
     <mu2>1</mu2>
-    <selfCollide>true</selfCollide>
+    <!--selfCollide>true</selfCollide-->
    <material>Gazebo/Grey</material>
 </gazebo>
 
-<gazebo reference="komodo_$(arg komodo_id)_elbow1_link">
+<gazebo reference="komodo_elbow1_link">
     <mu1>1</mu1>
     <mu2>1</mu2>
-    <selfCollide>true</selfCollide>
+    <!--selfCollide>true</selfCollide-->
    <material>Gazebo/Grey</material>
 </gazebo>
 
-<gazebo reference="komodo_$(arg komodo_id)_elbow2_link">
+<gazebo reference="komodo_elbow2_link">
     <mu1>1</mu1>
     <mu2>1</mu2>
-    <selfCollide>true</selfCollide>
+    <!--selfCollide>true</selfCollide-->
    <material>Gazebo/Grey</material>
 </gazebo>
 
-<gazebo reference="komodo_$(arg komodo_id)_wrist_link">
+<gazebo reference="komodo_wrist_link">
     <mu1>1</mu1>
     <mu2>1</mu2>
-    <selfCollide>true</selfCollide>
+    <!--selfCollide>true</selfCollide-->
 </gazebo>
 
-<gazebo reference="komodo_$(arg komodo_id)_left_finger_link">
+<gazebo reference="komodo_left_finger_link">
     <mu1>1</mu1>
     <mu2>1</mu2>
-    <selfCollide>true</selfCollide>
+    <!--selfCollide>true</selfCollide-->
 </gazebo>
 
-<gazebo reference="komodo_$(arg komodo_id)_right_finger_link">
+<gazebo reference="komodo_right_finger_link">
     <mu1>1</mu1>
     <mu2>1</mu2>
-    <selfCollide>true</selfCollide>
+    <!--selfCollide>true</selfCollide-->
 </gazebo>
 
-  <gazebo reference="komodo_$(arg komodo_id)_base_link">
+  <gazebo reference="komodo_base_link">
     <material>Gazebo/Grey</material>
     <mu1>1</mu1>
     <mu2>1</mu2>
-    <selfCollide>true</selfCollide>
+    <!--selfCollide>true</selfCollide-->
   </gazebo>
-<gazebo reference="komodo_$(arg komodo_id)_FR_Wheel_link">
+<gazebo reference="komodo_FR_Wheel_link">
     <mu1>1</mu1>
     <mu2>1</mu2>
-    <selfCollide>true</selfCollide>
+    <!--selfCollide>true</selfCollide-->
     <material>Gazebo/Grey</material>
 </gazebo>
-<gazebo reference="komodo_$(arg komodo_id)_FL_Wheel_link">
+<gazebo reference="komodo_FL_Wheel_link">
     <mu1>1</mu1>
     <mu2>1</mu2>
-    <selfCollide>true</selfCollide>
+    <!--selfCollide>true</selfCollide-->
     <material>Gazebo/Grey</material>
 </gazebo>
-<gazebo reference="komodo_$(arg komodo_id)_RR_Wheel_link">
+<gazebo reference="komodo_RR_Wheel_link">
     <mu1>1</mu1>
     <mu2>1</mu2>
-    <selfCollide>true</selfCollide>
+    <!--selfCollide>true</selfCollide-->
     <material>Gazebo/Grey</material>
 </gazebo>
-<gazebo reference="komodo_$(arg komodo_id)_RL_Wheel_link">
+<gazebo reference="komodo_RL_Wheel_link">
     <mu1>1</mu1>
     <mu2>1</mu2>
-    <selfCollide>true</selfCollide>
+    <!--selfCollide>true</selfCollide-->
     <material>Gazebo/Grey</material>
 </gazebo>
 
 <!-- arm camera -->
-  <gazebo reference="komodo_$(arg komodo_id)_Arm_Camera_link">
+  <gazebo reference="komodo_Arm_Camera_link">
     <sensor type="camera" name="camera1">
       <visualize>false</visualize>
       <update_rate>30.0</update_rate>
@@ -1373,10 +1392,11 @@
       <plugin name="camera_controller" filename="libgazebo_ros_camera.so">
         <alwaysOn>true</alwaysOn>
         <updateRate>40.0</updateRate>
-        <cameraName>komodo_$(arg komodo_id)/arm_camera</cameraName>
-        <imageTopicName>komodo_$(arg komodo_id)/arm_camera/image_raw</imageTopicName>
-        <cameraInfoTopicName>komodo_$(arg komodo_id)/arm_camera/camera_info</cameraInfoTopicName>
-        <frameName>komodo_$(arg komodo_id)_Arm_Camera_link</frameName>
+   <robotNamespace>/komodo_$(arg komodo_id)</robotNamespace>
+        <cameraName>/komodo_$(arg komodo_id)/arm_camera</cameraName>
+        <imageTopicName>/komodo_$(arg komodo_id)/arm_camera/image_raw</imageTopicName>
+        <cameraInfoTopicName>/komodo_$(arg komodo_id)/arm_camera/camera_info</cameraInfoTopicName>
+        <frameName>komodo_Arm_Camera_link</frameName>
         <hackBaseline>0.07</hackBaseline>
         <distortionK1>0.0</distortionK1>
         <distortionK2>0.0</distortionK2>
@@ -1389,8 +1409,8 @@
 
 <!-- Asus camera  - Gazebo -->
 
-<gazebo reference="komodo_$(arg komodo_id)_Asus_Camera_link">
-<sensor type="depth" name="komodo_$(arg komodo_id)_Asus_Camera_link">
+<gazebo reference="komodo_Asus_Camera_link">
+<sensor type="depth" name="komodo_Asus_Camera_link">
 <pose>0 0 0 0 0 0</pose>
 <visualize>true</visualize>
 <update_rate>20</update_rate>
@@ -1406,17 +1426,18 @@
 <far>9</far>
 </clip>
 </camera>
-<plugin name="komodo_$(arg komodo_id)_Asus_Camera_link_camera_controller" filename="libgazebo_ros_openni_kinect.so">
+<plugin name="komodo_Asus_Camera_link_camera_controller" filename="libgazebo_ros_openni_kinect.so">
 <alwaysOn>true</alwaysOn>
 <updateRate>20</updateRate>
 <cameraName>komodo_$(arg komodo_id)/komodo_Asus_Camera</cameraName>
+<robotNamespace>/komodo_$(arg komodo_id)</robotNamespace>
 <imageTopicName>/komodo_$(arg komodo_id)/komodo_Asus_Camera/rgb/image_raw</imageTopicName>
 <cameraInfoTopicName>/komodo_$(arg komodo_id)/komodo_Asus_Camera/rgb/camera_info</cameraInfoTopicName>
 <depthImageTopicName>/komodo_$(arg komodo_id)/komodo_Asus_Camera/depth/image_raw</depthImageTopicName>
 <depthImageCameraInfoTopicName>/komodo_$(arg komodo_id)/komodo_Asus_Camera/depth/camera_info</depthImageCameraInfoTopicName>
 <pointCloudTopicName>/komodo_$(arg komodo_id)/komodo_Asus_Camera/depth/points</pointCloudTopicName>
 <pointCloudCutoff>0.4</pointCloudCutoff>  
-<frameName>komodo_$(arg komodo_id)_Asus_Camera_link</frameName>
+<frameName>komodo_Asus_Camera_link</frameName>
 <distortion_k1>0.0</distortion_k1>
 <distortion_k2>0.0</distortion_k2>
 <distortion_k3>0.0</distortion_k3>
@@ -1461,7 +1482,7 @@
       </gazebo -->
 
   <!-- hokuyo -->
-  <gazebo reference="komodo_$(arg komodo_id)_Laser_link">
+  <gazebo reference="komodo_Laser_link">
     <sensor type="ray" name="head_hokuyo_sensor">
       <pose>0 0 0 0 0 0</pose>
       <visualize>false</visualize>
@@ -1492,7 +1513,7 @@
       </ray>
       <plugin name="gazebo_ros_head_hokuyo_controller" filename="libgazebo_ros_laser.so">
         <topicName>/komodo_$(arg komodo_id)/laser/scan</topicName>
-        <frameName>komodo_$(arg komodo_id)_Laser_link</frameName>
+        <frameName>komodo_Laser_link</frameName>
       </plugin>
     </sensor>
   </gazebo>
@@ -1501,8 +1522,8 @@
 <!-- name = komodo_Right_URF
      update rate = 20.0
  -->
-   <gazebo reference="komodo_$(arg komodo_id)_Right_URF_link">
-      <sensor type="ray" name="komodo_$(arg komodo_id)_Right_URF">
+   <gazebo reference="komodo_Right_URF_link">
+      <sensor type="ray" name="komodo_Right_URF">
         <always_on>true</always_on>
         <update_rate>20.0</update_rate>
         <pose>0 0 0 0 0 0</pose>
@@ -1529,10 +1550,10 @@
           </range>
         </ray>
 
-        <plugin name="gazebo_ros_komodo_$(arg komodo_id)_Right_URF_controller" filename="libhector_gazebo_ros_sonar.so">
+        <plugin name="gazebo_ros_komodo_Right_URF_controller" filename="libhector_gazebo_ros_sonar.so">
           <!--gaussianNoise>0.005</gaussianNoise-->
           <topicName>komodo_$(arg komodo_id)/Rangers/Right_URF</topicName>
-          <frameId>komodo_$(arg komodo_id)_Right_URF_link</frameId>
+          <frameId>komodo_Right_URF_link</frameId>
         </plugin>
       </sensor>
     </gazebo>
@@ -1541,8 +1562,8 @@
 <!-- name = komodo_Left_URF
      update rate = 20.0
  -->
-   <gazebo reference="komodo_$(arg komodo_id)_Left_URF_link">
-      <sensor type="ray" name="komodo_$(arg komodo_id)_Left_URF">
+   <gazebo reference="komodo_Left_URF_link">
+      <sensor type="ray" name="komodo_Left_URF">
         <always_on>true</always_on>
         <update_rate>20.0</update_rate>
         <pose>0 0 0 0 0 0</pose>
@@ -1569,18 +1590,18 @@
           </range>
         </ray>
 
-        <plugin name="gazebo_ros_komodo_$(arg komodo_id)_Left_URF_controller" filename="libhector_gazebo_ros_sonar.so">
+        <plugin name="gazebo_ros_komodo_Left_URF_controller" filename="libhector_gazebo_ros_sonar.so">
           <!--gaussianNoise>0.005</gaussianNoise-->
           <topicName>komodo_$(arg komodo_id)/Rangers/Left_URF</topicName>
-          <frameId>komodo_$(arg komodo_id)_Left_URF_link</frameId>
+          <frameId>komodo_Left_URF_link</frameId>
         </plugin>
       </sensor>
     </gazebo>
 
 <!--komodo_Rear_URF -->
 
-   <gazebo reference="komodo_$(arg komodo_id)_Rear_URF_link">
-      <sensor type="ray" name="komodo_$(arg komodo_id)_Rear_URF">
+   <gazebo reference="komodo_Rear_URF_link">
+      <sensor type="ray" name="komodo_Rear_URF">
         <always_on>true</always_on>
         <update_rate>20.0</update_rate>
         <pose>0 0 0 0 0 0</pose>
@@ -1607,19 +1628,19 @@
           </range>
         </ray>
 
-        <plugin name="gazebo_ros_komodo_$(arg komodo_id)_Rear_URF_controller" filename="libhector_gazebo_ros_sonar.so">
+        <plugin name="gazebo_ros_komodo_Rear_URF_controller" filename="libhector_gazebo_ros_sonar.so">
           <!--gaussianNoise>0.005</gaussianNoise-->
           <topicName>komodo_$(arg komodo_id)/Rangers/Rear_URF</topicName>
-          <frameId>komodo_$(arg komodo_id)_Rear_URF_link</frameId>
+          <frameId>komodo_Rear_URF_link</frameId>
         </plugin>
       </sensor>
     </gazebo>
 
 <!-- IMU -->
   <gazebo>
-    <plugin name="komodo_$(arg komodo_id)_imu_sim" filename="libhector_gazebo_ros_imu.so">
+    <plugin name="komodo_imu_sim" filename="libhector_gazebo_ros_imu.so">
       <updateRate>100.0</updateRate>
-      <bodyName>komodo_$(arg komodo_id)_base_link</bodyName>
+      <bodyName>komodo_dummy_link</bodyName>
       <topicName>komodo_$(arg komodo_id)/imu_pub</topicName>
       <rpyOffsets>0 0 0</rpyOffsets> <!-- deprecated -->
       <gaussianNoise>0</gaussianNoise>  <!-- deprecated -->
@@ -1638,18 +1659,20 @@
     <updateRate>100.0</updateRate>
     <robotNamespace>/komodo_$(arg komodo_id)</robotNamespace>
     <broadcastTF>1</broadcastTF>
-    <leftFrontJoint>komodo_$(arg komodo_id)_FL_Wheel_joint</leftFrontJoint>
-    <rightFrontJoint>komodo_$(arg komodo_id)_FR_Wheel_joint</rightFrontJoint>
-    <leftRearJoint>komodo_$(arg komodo_id)_RL_Wheel_joint</leftRearJoint>
-    <rightRearJoint>komodo_$(arg komodo_id)_RR_Wheel_joint</rightRearJoint>
+    <leftFrontJoint>komodo_FL_Wheel_joint</leftFrontJoint>
+    <rightFrontJoint>komodo_FR_Wheel_joint</rightFrontJoint>
+    <leftRearJoint>komodo_RL_Wheel_joint</leftRearJoint>
+    <rightRearJoint>komodo_RR_Wheel_joint</rightRearJoint>
     <wheelSeparation>0.5</wheelSeparation>
     <wheelDiameter>0.2</wheelDiameter>
-    <robotBaseFrame>komodo_$(arg komodo_id)_base_link</robotBaseFrame>
-    <odometryTopic>odom</odometryTopic>
-    <odometryFrame>odom</odometryFrame>
+    <robotBaseFrame>komodo_dummy_link</robotBaseFrame>
+    <odometryTopic>odom_$(arg komodo_id)</odometryTopic>
+    <odometryFrame>odom_$(arg komodo_id)</odometryFrame>
     <torque>20</torque>
     <commandTopic>cmd_vel</commandTopic>
   </plugin>
-    <plugin name="gazebo_ros_control" filename="libgazebo_ros_control.so"/>
+    <plugin name="gazebo_ros_control" filename="libgazebo_ros_control.so">
+    <robotNamespace>/komodo_st_$(arg komodo_id)</robotNamespace>
+    </plugin>
 </gazebo>
 </robot>

--- a/ric_description/launch/komodo.launch
+++ b/ric_description/launch/komodo.launch
@@ -1,0 +1,28 @@
+<!-- -*- mode: XML -*- -->
+<launch>
+  
+  <arg name="x" default="0.0"/>
+  <arg name="y" default="0.0"/>
+  <arg name="z" default="0.1"/>
+  <arg name="id" default="1"/>
+  <arg name="first" default="0"/>
+
+ <param name="tf_prefix" value="komodo_$(arg id)" />
+
+  
+  <!-- Load the URDF into the ROS Parameter Server -->
+ <param name="robot_description" command="$(find xacro)/xacro.py '$(find ric_description)/komodo/komodo.xacro' komodo_id:=$(arg id)" />
+
+<group unless="$(arg first)">
+  <!-- Run a python script to the send a service call to gazebo_ros to spawn a URDF robot -->
+  <node name="urdf_spawner_$(arg id)" pkg="gazebo_ros" type="spawn_model" respawn="false" output="screen"
+	args="-urdf -model komodo_$(arg id) -param robot_description -x $(arg x) -y $(arg y) -z $(arg z)"/>
+  </group>
+
+ <node name="pcloud_rot_node" pkg="pcloud_rot" type="pcloud_rot_node" cwd="node" output="screen" args="$(arg id)" />
+
+ <node pkg="tf" type="static_transform_publisher" name="komodo_broadcaster_$(arg id)" args="0 0 0 0 0 0 /map /komodo_$(arg id)/odom_$(arg id) 100" />
+
+ <!--/group-->
+
+</launch>

--- a/ric_description/launch/komodo_control.launch
+++ b/ric_description/launch/komodo_control.launch
@@ -1,8 +1,9 @@
 <!-- -*- mode: XML -*- -->
 <launch>
- <arg name="id" default="1"/>
-  <!-- Load joint controller configurations from YAML file to parameter server -->
-  <rosparam file="$(find ric_description)/config/ric_robot_control_$(arg id).yaml" command="load"/>
+<arg name="id" default="1"/>
+<!--group ns="komodo_1">
+  <Load joint controller configurations from YAML file to parameter server -->
+  <rosparam file="$(find ric_description)/config/ric_robot_control.yaml" command="load"/>
 
   <!-- load the controllers -->
   <node name="controller_spawner" pkg="controller_manager" type="spawner" respawn="false"
@@ -22,6 +23,9 @@
 	respawn="false" output="screen">
     <remap from="/joint_states" to="/komodo_$(arg id)/joint_states"/> 
 
+    <!--param name="~tf_prefix" value="komodo_$(arg id)" type="str"/-->
+
   </node> 
+<!--/group-->
 
 </launch>

--- a/ric_description/launch/two_komodo_gazebo.launch
+++ b/ric_description/launch/two_komodo_gazebo.launch
@@ -32,21 +32,21 @@
 
  <!-- Spawn URDF models under different name spaces -->
 
-	<group ns="komodo_1/">
+	<group ns="komodo_1">
 		<include file="$(find ric_description)/launch/komodo.launch">
 		<arg name="id" value="1"/>
 		<arg name="x" value="0.0" />
 		<arg name="y" value="0.0" />
 		<arg name="z" value="0.1" />
 		</include>
- <!-- ros_control clam launch file -->
+
+		 <!-- ros_control clam launch file -->
   		<include file="$(find ric_description)/launch/komodo_control.launch" >
 		<arg name="id" value="1"/>
  	       </include>
 	</group>
-		
 
-	<!--group ns="komodo_2">
+	<group ns="komodo_2">
 		<include file="$(find ric_description)/launch/komodo.launch">
 		<arg name="id" value="2"/>
 		<arg name="x" value="2" />
@@ -54,11 +54,11 @@
 		<arg name="z" value="0.1" />
 		</include>
 
-		 <ros_control clam launch file -
+		 <!--ros_control clam launch file -->
   		<include file="$(find ric_description)/launch/komodo_control.launch" >
 		<arg name="id" value="2"/>
  	       </include>
-	</group-->
+	</group>
 
 
 


### PR DESCRIPTION
Hi Yam,

These are the changes iv'e made, including three new launch files, one contains two robot launch (two_komodo_gaebo.launch) and komodo_gazebo launches only one.

The simulation is fully capable of supporting two robots \ one under tf_prefix and different group namespace.

Unfortunately , we have a problem with loading URF sensors under the specific TF prefixes. 
I think it has something to do with the "hector_gazebo" package. - i'll look for a solution later, it's late already.

Thanks,
Dudu.